### PR TITLE
Exclude django-reversion versions that don't support Django 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django           >= 1.6, < 1.7
-django-reversion >= 1.8
+django-reversion >= 1.8, < 1.9
 python-dateutil  <  2.0 # 2+ is only for python 3
 django_extensions
 django-apptemplates


### PR DESCRIPTION
`syncdb` runs into trouble with the most recent django-reversion version, which only supports Django > 1.6.